### PR TITLE
build: exclude dev dependencies when generating CycloneDX SBOM artifacts

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -90,7 +90,7 @@ jobs:
           poetry self add "poetry-dynamic-versioning[plugin]"
       - name: Generate CycloneDX SBOM artifacts 📃
         run: |
-          poetry run cyclonedx-py poetry --all-extras --of JSON -o depthviz-${{ github.ref_name }}.cyclonedx.json
+          poetry run cyclonedx-py poetry --without dev --all-extras --of JSON -o depthviz-${{ github.ref_name }}.cyclonedx.json
       - name: Build the package 📦
         run: |
           poetry build


### PR DESCRIPTION
## 🎯 Purpose of this PR  

This PR updates the CycloneDX **Software Bill of Materials (SBOM) generation** to exclude development dependencies, ensuring that only production dependencies are included in the final artifact. This helps keep the SBOM focused on essential runtime dependencies, improving clarity and security compliance.  

## 🛠️ Changes Made  

- Updated **CycloneDX SBOM configuration** to **exclude development dependencies** from the generated artifact.  
- Ensured that only **runtime dependencies** are included in the final SBOM report.  

## 📸 Screenshots or GIF (if applicable)  
N/A (Build-related change).  

## 📜 How to Test  

1. Run the CycloneDX SBOM generation command:  
   ```bash
   poetry run cyclonedx-py poetry --without dev --all-extras --of JSON -o depthviz.cyclonedx.json 
   ```  
2. Verify that **development dependencies are no longer included** in `sbom.xml`.  
3. Run tests to confirm:  
   ```bash
   tox
   ```  
   _Optionally, use `tox -p 10` for faster execution._  

## ✅ Checklist Before Merge

- [x] Code follows the project’s style guidelines.
- [x] PR is based on the `main` branch and is up to date.
- [x] All tests pass.
  <!-- You may run tests locally with: `tox` but it is not required since CI will run all the tests. -->
- [x] Documentation is updated (if applicable).
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have read the [CONTRIBUTING.md](https://github.com/noppanut15/depthviz/blob/main/CONTRIBUTING.md) guidelines.

## 💬 Additional Notes (optional)

<!--
Provide any extra context, edge cases considered, or future improvements.
-->
This update **keeps SBOM artifacts cleaner** and **ensures compliance with best practices** by omitting unnecessary development dependencies.