### PR TITLE
docs: add tqdm and colorama contributors to AUTHORS.md

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -11,6 +11,8 @@ If you have any questions, suggestions, or just want to chat about freediving te
 
 - **MoviePy** – [Zulko & contributors](https://github.com/Zulko/moviepy/graphs/contributors)  
 - **FIT Python SDK** – [Garmin & contributors](https://github.com/garmin/fit-python-sdk/graphs/contributors)  
+- **tqdm** – [Casper da Costa-Luis & contributors](https://github.com/tqdm/tqdm?tab=readme-ov-file#contributions)
+- **colorama** – [Jonathan Hartley & contributors](https://github.com/tartley/colorama/graphs/contributors)
 - **Open Sans font** – [Steve Matteson & contributors](https://github.com/googlefonts/opensans/graphs/contributors)  
 
 ### 🧪 Testing & Code Quality Dependencies  


### PR DESCRIPTION
## 🎯 Purpose of this PR  

This PR updates **AUTHORS.md** to acknowledge the contributors of **tqdm** and **colorama**, which are now dependencies in **depthviz**. 

## 🛠️ Changes Made  

- **Added tqdm contributors**:  
  - [Casper da Costa-Luis & contributors](https://github.com/tqdm/tqdm?tab=readme-ov-file#contributions)
- **Added colorama contributors**:  
  - [Jonathan Hartley & contributors](https://github.com/tartley/colorama/graphs/contributors)

## 📜 How to Test  

1. Open **AUTHORS.md** in a Markdown viewer or on GitHub.  
2. Verify that **tqdm** and **colorama** contributors are correctly listed under dependencies.  
3. Ensure the links to their contributor pages are working properly.  

## ✅ Checklist Before Merge  

- [x] Code follows the project’s style guidelines.  
- [x] PR is based on the `main` branch and is up to date.  
- [x] All tests pass.  
  <!-- You may run tests locally with: `tox` but it is not required since CI will run all the tests. -->  
- [x] Documentation is updated (if applicable).  
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] I have read the [CONTRIBUTING.md](https://github.com/noppanut15/depthviz/blob/main/CONTRIBUTING.md) guidelines.  

## 💬 Additional Notes (optional)  
N/A