### PR TITLE
feat: add support for depth data in both meters and millibars for Shearwater logs

### DIFF
--- a/tests/data/shearwater/valid_depth_data_oc_tec_trimmed.xml
+++ b/tests/data/shearwater/valid_depth_data_oc_tec_trimmed.xml
@@ -1,0 +1,184 @@
+<?xml version="1.0" encoding="utf-16"?>
+<dive xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="3">
+  <diveLog>
+    <number>999</number>
+    <gfMin>50</gfMin>
+    <gfMax>70</gfMax>
+    <surfaceMins>1392</surfaceMins>
+    <imperialUnits>false</imperialUnits>
+    <startBatteryVoltage>4.20000029</startBatteryVoltage>
+    <startCns>0</startCns>
+    <startDate>1/1/2024 1:07:14 PM</startDate>
+    <startO2SensorStatus>false</startO2SensorStatus>
+    <startLowSetPoint>0</startLowSetPoint>
+    <startHighSetPoint>1</startHighSetPoint>
+    <computerFirmware>23</computerFirmware>
+    <maxDepth>41.2</maxDepth>
+    <maxTime>3124</maxTime>
+    <errorHistory />
+    <endBatteryVoltage>4.20000029</endBatteryVoltage>
+    <endCns>14</endCns>
+    <endDate>1/1/2024 1:59:18 PM</endDate>
+    <endO2SensorStatus>false</endO2SensorStatus>
+    <endLowSetPoint>0</endLowSetPoint>
+    <endHighSetPoint>0</endHighSetPoint>
+    <computerSerial>XXXXXXXX</computerSerial>
+    <computerSoftwareVersion>23</computerSoftwareVersion>
+    <computerModel>0</computerModel>
+    <logVersion>13</logVersion>
+    <decoModel>0</decoModel>
+    <vpmbConservatism>3</vpmbConservatism>
+    <startSurfacePressure>996</startSurfacePressure>
+    <endSurfacePressure>996</endSurfacePressure>
+    <sensorDisplay>0</sensorDisplay>
+    <product>8</product>
+    <features>0</features>
+    <diveLogRecords>
+      <diveLogRecord>
+        <currentTime>0</currentTime>
+        <currentDepth>0.3</currentDepth>
+        <firstStopDepth>0</firstStopDepth>
+        <ttsMins>0</ttsMins>
+        <averagePPO2>0.21</averagePPO2>
+        <fractionO2>0.21</fractionO2>
+        <fractionHe>0</fractionHe>
+        <firstStopTime>0</firstStopTime>
+        <currentNdl>0</currentNdl>
+        <currentCircuitSetting>OC/BO</currentCircuitSetting>
+        <currentCcrModeSettings>0</currentCcrModeSettings>
+        <waterTemp>29</waterTemp>
+        <gasSwitchNeeded>false</gasSwitchNeeded>
+        <externalPPO2>0</externalPPO2>
+        <setPointType>0</setPointType>
+        <circuitSwitchType>0</circuitSwitchType>
+        <sensor1Millivolts>0</sensor1Millivolts>
+        <sensor2Millivolts>0</sensor2Millivolts>
+        <sensor3Millivolts>0</sensor3Millivolts>
+        <batteryVoltage>4.19</batteryVoltage>
+        <tank0pressurePSI>AI is off</tank0pressurePSI>
+        <tank1pressurePSI>AI is off</tank1pressurePSI>
+        <tank2pressurePSI>AI is off</tank2pressurePSI>
+        <tank3pressurePSI>AI is off</tank3pressurePSI>
+        <gasTime>Not paired</gasTime>
+        <sac>AI is off</sac>
+        <sad>0</sad>
+      </diveLogRecord>
+      <diveLogRecord>
+        <currentTime>10000</currentTime>
+        <currentDepth>2.9</currentDepth>
+        <firstStopDepth>0</firstStopDepth>
+        <ttsMins>1</ttsMins>
+        <averagePPO2>0.26</averagePPO2>
+        <fractionO2>0.21</fractionO2>
+        <fractionHe>0</fractionHe>
+        <firstStopTime>0</firstStopTime>
+        <currentNdl>99</currentNdl>
+        <currentCircuitSetting>OC/BO</currentCircuitSetting>
+        <currentCcrModeSettings>0</currentCcrModeSettings>
+        <waterTemp>29</waterTemp>
+        <gasSwitchNeeded>false</gasSwitchNeeded>
+        <externalPPO2>0</externalPPO2>
+        <setPointType>0</setPointType>
+        <circuitSwitchType>0</circuitSwitchType>
+        <sensor1Millivolts>0</sensor1Millivolts>
+        <sensor2Millivolts>0</sensor2Millivolts>
+        <sensor3Millivolts>0</sensor3Millivolts>
+        <batteryVoltage>4.19</batteryVoltage>
+        <tank0pressurePSI>AI is off</tank0pressurePSI>
+        <tank1pressurePSI>AI is off</tank1pressurePSI>
+        <tank2pressurePSI>AI is off</tank2pressurePSI>
+        <tank3pressurePSI>AI is off</tank3pressurePSI>
+        <gasTime>Not paired</gasTime>
+        <sac>AI is off</sac>
+        <sad>0</sad>
+      </diveLogRecord>
+      <diveLogRecord>
+        <currentTime>20000</currentTime>
+        <currentDepth>4.1</currentDepth>
+        <firstStopDepth>0</firstStopDepth>
+        <ttsMins>1</ttsMins>
+        <averagePPO2>0.29</averagePPO2>
+        <fractionO2>0.21</fractionO2>
+        <fractionHe>0</fractionHe>
+        <firstStopTime>0</firstStopTime>
+        <currentNdl>99</currentNdl>
+        <currentCircuitSetting>OC/BO</currentCircuitSetting>
+        <currentCcrModeSettings>0</currentCcrModeSettings>
+        <waterTemp>29</waterTemp>
+        <gasSwitchNeeded>false</gasSwitchNeeded>
+        <externalPPO2>0</externalPPO2>
+        <setPointType>0</setPointType>
+        <circuitSwitchType>0</circuitSwitchType>
+        <sensor1Millivolts>0</sensor1Millivolts>
+        <sensor2Millivolts>0</sensor2Millivolts>
+        <sensor3Millivolts>0</sensor3Millivolts>
+        <batteryVoltage>4.19</batteryVoltage>
+        <tank0pressurePSI>AI is off</tank0pressurePSI>
+        <tank1pressurePSI>AI is off</tank1pressurePSI>
+        <tank2pressurePSI>AI is off</tank2pressurePSI>
+        <tank3pressurePSI>AI is off</tank3pressurePSI>
+        <gasTime>Not paired</gasTime>
+        <sac>AI is off</sac>
+        <sad>0</sad>
+      </diveLogRecord>
+      <diveLogRecord>
+        <currentTime>30000</currentTime>
+        <currentDepth>5.20000029</currentDepth>
+        <firstStopDepth>0</firstStopDepth>
+        <ttsMins>1</ttsMins>
+        <averagePPO2>0.31</averagePPO2>
+        <fractionO2>0.21</fractionO2>
+        <fractionHe>0</fractionHe>
+        <firstStopTime>0</firstStopTime>
+        <currentNdl>99</currentNdl>
+        <currentCircuitSetting>OC/BO</currentCircuitSetting>
+        <currentCcrModeSettings>0</currentCcrModeSettings>
+        <waterTemp>29</waterTemp>
+        <gasSwitchNeeded>false</gasSwitchNeeded>
+        <externalPPO2>0</externalPPO2>
+        <setPointType>0</setPointType>
+        <circuitSwitchType>0</circuitSwitchType>
+        <sensor1Millivolts>0</sensor1Millivolts>
+        <sensor2Millivolts>0</sensor2Millivolts>
+        <sensor3Millivolts>0</sensor3Millivolts>
+        <batteryVoltage>4.19</batteryVoltage>
+        <tank0pressurePSI>AI is off</tank0pressurePSI>
+        <tank1pressurePSI>AI is off</tank1pressurePSI>
+        <tank2pressurePSI>AI is off</tank2pressurePSI>
+        <tank3pressurePSI>AI is off</tank3pressurePSI>
+        <gasTime>Not paired</gasTime>
+        <sac>AI is off</sac>
+        <sad>0</sad>
+      </diveLogRecord>
+      <diveLogRecord>
+        <currentTime>40000</currentTime>
+        <currentDepth>5.6</currentDepth>
+        <firstStopDepth>0</firstStopDepth>
+        <ttsMins>1</ttsMins>
+        <averagePPO2>0.32</averagePPO2>
+        <fractionO2>0.21</fractionO2>
+        <fractionHe>0</fractionHe>
+        <firstStopTime>0</firstStopTime>
+        <currentNdl>99</currentNdl>
+        <currentCircuitSetting>OC/BO</currentCircuitSetting>
+        <currentCcrModeSettings>0</currentCcrModeSettings>
+        <waterTemp>29</waterTemp>
+        <gasSwitchNeeded>false</gasSwitchNeeded>
+        <externalPPO2>0</externalPPO2>
+        <setPointType>0</setPointType>
+        <circuitSwitchType>0</circuitSwitchType>
+        <sensor1Millivolts>0</sensor1Millivolts>
+        <sensor2Millivolts>0</sensor2Millivolts>
+        <sensor3Millivolts>0</sensor3Millivolts>
+        <batteryVoltage>4.19</batteryVoltage>
+        <tank0pressurePSI>AI is off</tank0pressurePSI>
+        <tank1pressurePSI>AI is off</tank1pressurePSI>
+        <tank2pressurePSI>AI is off</tank2pressurePSI>
+        <tank3pressurePSI>AI is off</tank3pressurePSI>
+        <gasTime>Not paired</gasTime>
+        <sac>AI is off</sac>
+        <sad>0</sad>
+      </diveLogRecord>
+    </diveLogRecords>
+  </diveLog>
+</dive>

--- a/tests/test_shearwater_xml_parser.py
+++ b/tests/test_shearwater_xml_parser.py
@@ -344,3 +344,28 @@ class TestShearwaterXmlParser:
         parser = ShearwaterXmlParser(depth_mode=depth_mode)
         parser.parse(file_path)
         mock_depth_mode_execute.assert_called_once()
+
+    def test_parse_valid_xml_scuba_longdive(
+        self, request: pytest.FixtureRequest
+    ) -> None:
+        """Test parsing a valid XML file with scuba long dive (OC Tec).
+
+        Note:
+            Scuba dive logs record the depth data in meters so we need to add
+            support both meters and millibars.
+        """
+        file_path = str(
+            request.path.parent.joinpath(
+                "data", "shearwater", "valid_depth_data_oc_tec_trimmed.xml"
+            )
+        )
+        xml_parser = ShearwaterXmlParser()
+        xml_parser.parse(file_path)
+        assert xml_parser.get_depth_data() == [0.3, 2.9, 4.1, 5.2, 5.6]
+        assert xml_parser.get_time_data() == [
+            0.0,
+            10.0,
+            20.0,
+            30.0,
+            40.0,
+        ]


### PR DESCRIPTION
## 🎯 Purpose of this PR  

This PR enhances the **Shearwater XML parser** to support **depth data recorded in both meters and millibars**. This ensures compatibility with different depth logging formats used by Shearwater dive computers, improving accuracy in depth visualization.  

## 🛠️ Changes Made  

### **🔹 Feature Updates**  
- **Added support for depth units (`mbar`, `m`)**:  
  - The parser now determines whether depth values are in **millibars (mbar) or meters (m)**.  
  - If the depth is in millibars, it is converted to meters using hydrostatic pressure calculations.  
  - If already in meters, the value is used directly.  

### **🔧 Code Changes**  
- Introduced `__depth_unit` attribute to **ShearwaterXmlParser** to track depth unit detection.  
- Implemented logic to **automatically determine depth unit** based on recorded values.  
- Updated `_get_depth_meter()` method to **handle both millibar and meter-based depth logs**.  

### **🧪 Test Coverage**  
- **Added new test case**: `test_parse_valid_xml_scuba_longdive`  
  - Ensures the parser correctly reads **depth values in meters** for a Shearwater **OC Tec** dive log.  
  - Validates both **depth data** and **time data** extraction.  
- **Introduced new test XML file (`valid_depth_data_oc_tec_trimmed.xml`)**  
  - Contains a sample Shearwater dive log with **depth data in meters**.  

## 📸 Screenshots or GIF (if applicable)  

N/A (Feature is backend-related).  

## 📜 How to Test  

1. Run the **new test case**:  
   ```bash
   tox
   ```  
2. Verify that depth data is correctly extracted from the Shearwater XML file:  
   ```python
   assert xml_parser.get_depth_data() == [0.3, 2.9, 4.1, 5.2, 5.6]
   ```  
3. Confirm that the time data aligns with the recorded depth points:  
   ```python
   assert xml_parser.get_time_data() == [0.0, 10.0, 20.0, 30.0, 40.0]
   ```  
4. Ensure that the parser correctly distinguishes **millibar vs. meter depth units** based on the log values.  

## ✅ Checklist Before Merge  

- [x] Code follows the project’s style guidelines.  
- [x] PR is based on the `main` branch and is up to date.  
- [x] All tests pass.  
  <!-- You may run tests locally with: `tox` but it is not required since CI will run all the tests. -->  
- [x] Documentation is updated (if applicable).  
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).  
- [x] I have read the [CONTRIBUTING.md](https://github.com/noppanut15/depthviz/blob/main/CONTRIBUTING.md) guidelines.  

## 💬 Additional Notes (optional)  

This update **ensures depthviz can process Shearwater dive logs with both meters and millibars**, making it more versatile for different dive logging formats. (Scuba & Freediving)